### PR TITLE
Necessary to compile on OS X

### DIFF
--- a/ccminer.cpp
+++ b/ccminer.cpp
@@ -451,6 +451,9 @@ static void affine_to_cpu_mask(int id, uint8_t mask) {
 	}
 	cpuset_setaffinity(CPU_LEVEL_WHICH, CPU_WHICH_TID, -1, sizeof(cpuset_t), &set);
 }
+#elif defined(__APPLE__)
+static inline void drop_policy(void) { }
+static void affine_to_cpu_mask(int id, uint8_t mask) {}
 #else /* Windows */
 static inline void drop_policy(void) { }
 static void affine_to_cpu_mask(int id, uint8_t mask) {

--- a/configure.ac
+++ b/configure.ac
@@ -131,11 +131,14 @@ AC_CONFIG_FILES([
 
 dnl find out what version we are running
 ARCH=`uname -m`
-if [[ $ARCH == "x86_64" ]];
+OS=`uname -s`
+SUFFIX=""
+if [[ $ARCH == "x86_64" && $OS != "Darwin" ]];
 then
   SUFFIX="64"
-else
-  SUFFIX=""
+elif [[ $OS == "Darwin" ]];
+then
+  CXXFLAGS="$CXXFLAGS -lc++"
 fi
 
 dnl Setup CUDA paths


### PR DESCRIPTION
 because OS X doesn't have a function for cpu affinity
